### PR TITLE
feat: add height and weight input fields to AdminOverviewScreen

### DIFF
--- a/app/Admin/(tabs)/index.tsx
+++ b/app/Admin/(tabs)/index.tsx
@@ -51,6 +51,25 @@ export default function AdminOverviewScreen() {
             onChangeText={setWeight}
           />
         </View>
+
+        <View className="flex-row gap-3">
+          <TextInput
+            className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-base text-slate-900"
+            placeholder="Height (cm)"
+            placeholderTextColor="#9CA3AF"
+            keyboardType="numeric"
+            value={height}
+            onChangeText={setHeight}
+          />
+          <TextInput
+            className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-base text-slate-900"
+            placeholder="Weight (kg)"
+            placeholderTextColor="#9CA3AF"
+            keyboardType="numeric"
+            value={weight}
+            onChangeText={setWeight}
+          />
+        </View>
       </View>
 
       <TouchableOpacity className="mt-8 rounded-xl bg-violet-700 px-4 py-3 active:bg-violet-800">


### PR DESCRIPTION
This pull request adds a new section to the `AdminOverviewScreen` that allows users to input both height and weight using two side-by-side text inputs. This improves the user experience by making it easier to enter these related values in a single view.

**UI enhancements:**

* Added a new `View` containing two `TextInput` fields for entering height (in cm) and weight (in kg), styled to appear side by side for improved usability in `AdminOverviewScreen` (`app/Admin/(tabs)/index.tsx`).